### PR TITLE
#8 feat : 친구 검색, 친구 추가 (FriendsState 도메인) API 개발 완료

### DIFF
--- a/whatsong/src/main/java/dy/whatsong/domain/healthcheck/api/HealthCheckAPI.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/healthcheck/api/HealthCheckAPI.java
@@ -1,0 +1,15 @@
+package dy.whatsong.domain.healthcheck.api;
+
+import dy.whatsong.global.annotation.EssentialController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@EssentialController
+public class HealthCheckAPI {
+
+	@GetMapping("/healthcheck")
+	public ResponseEntity<?> healthcheckServer(){
+		return new ResponseEntity<>("Ping pololopongpongpong", HttpStatus.OK);
+	}
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/member/api/MemberDetailAPI.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/api/MemberDetailAPI.java
@@ -1,0 +1,25 @@
+package dy.whatsong.domain.member.api;
+
+import dy.whatsong.domain.member.application.service.MemberDetailService;
+import dy.whatsong.domain.member.dto.MemberRequestDTO;
+import dy.whatsong.global.annotation.EssentialController;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@EssentialController
+@RequiredArgsConstructor
+public class MemberDetailAPI {
+	private final MemberDetailService memberDetailService;
+
+	@PostMapping("/friends/search")
+	public ResponseEntity<?> searchOnMemberList(@RequestBody MemberRequestDTO.Search searchDTO){
+		return memberDetailService.memberSearchOnFriendsList(searchDTO);
+	}
+
+	@PostMapping("/friends/apply")
+	public ResponseEntity<?> applyOnMember(@RequestBody MemberRequestDTO.FriendsApply friendsApplyDTO){
+		return memberDetailService.memberFriendRequest(friendsApplyDTO);
+	}
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
@@ -4,10 +4,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dy.whatsong.domain.member.application.service.MemberDetailService;
 import dy.whatsong.domain.member.dto.MemberRequestDTO;
-import dy.whatsong.domain.member.entity.FriendsState;
-import dy.whatsong.domain.member.entity.Member;
-import dy.whatsong.domain.member.entity.MemberRole;
-import dy.whatsong.domain.member.entity.QFriendsState;
+import dy.whatsong.domain.member.entity.*;
 import dy.whatsong.domain.member.repo.FriendsStateRepository;
 import dy.whatsong.global.annotation.EssentialServiceLayer;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +13,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @EssentialServiceLayer
 @RequiredArgsConstructor
@@ -53,6 +52,18 @@ public class MemberDetailServiceImpl implements MemberDetailService {
 				.from(qfs)
 				.where(friendConditon)
 				.fetchFirst() != null;
+	}
+
+	@Override
+	public ResponseEntity<?> memberSearchOnFriendsList(MemberRequestDTO.Search searchDTO) {
+		QMember qMember= QMember.member;
+		BooleanExpression friendsCandidate = qMember.memberSeq.ne(searchDTO.getOwnerSeq())
+				.and(qMember.innerNickname.startsWith(searchDTO.getTargetName()));
+		List<Member> fetchResult = jpaQueryFactory.selectFrom(qMember)
+				.where(friendsCandidate)
+				.fetch();
+
+		return new ResponseEntity<>(fetchResult,HttpStatus.OK);
 	}
 
 	public Member testDummy(){

--- a/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
@@ -5,6 +5,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import dy.whatsong.domain.member.application.service.MemberDetailService;
 import dy.whatsong.domain.member.dto.MemberRequestDTO;
 import dy.whatsong.domain.member.entity.FriendsState;
+import dy.whatsong.domain.member.entity.Member;
+import dy.whatsong.domain.member.entity.MemberRole;
 import dy.whatsong.domain.member.entity.QFriendsState;
 import dy.whatsong.domain.member.repo.FriendsStateRepository;
 import dy.whatsong.global.annotation.EssentialServiceLayer;
@@ -51,5 +53,16 @@ public class MemberDetailServiceImpl implements MemberDetailService {
 				.from(qfs)
 				.where(friendConditon)
 				.fetchFirst() != null;
+	}
+
+	public Member testDummy(){
+		return Member.builder()
+				.memberSeq(1L)
+				.nickname("dummy")
+				.innerNickname("bomin")
+				.memberRole(MemberRole.USER)
+				.email("dummy@dummy.com")
+				.imgURL("https://avatars.githubusercontent.com/u/65716445?v=4")
+				.build();
 	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/member/application/service/MemberDetailService.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/application/service/MemberDetailService.java
@@ -7,4 +7,6 @@ public interface MemberDetailService {
 	ResponseEntity<?> memberFriendRequest(MemberRequestDTO.FriendsApply friendsApplyDTO);
 
 	boolean isAlreadyFriends(Long ownerSeq,Long requestMemberSeq);
+
+	ResponseEntity<?> memberSearchOnFriendsList(MemberRequestDTO.Search searchDTO);
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/member/dto/MemberRequestDTO.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/dto/MemberRequestDTO.java
@@ -10,4 +10,10 @@ public class MemberRequestDTO {
 		private Long ownerSeq;
 		private Long targetSeq;
 	}
+
+	@Getter
+	public static class Search{
+		private Long ownerSeq;
+		private String targetName;
+	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/api/MusicRoomAPIController.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/api/MusicRoomAPIController.java
@@ -1,13 +1,37 @@
 package dy.whatsong.domain.music.api;
 
+import dy.whatsong.domain.music.application.service.MusicRoomService;
+import dy.whatsong.domain.music.dto.request.MusicRequestDTO;
 import dy.whatsong.global.annotation.EssentialController;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
-@RestController
-@RequestMapping
+import javax.websocket.server.PathParam;
+
 @EssentialController
+@RequiredArgsConstructor
 public class MusicRoomAPIController {
+	private final MusicRoomService musicRoomService;
+
+	@PostMapping("/musicRoom")
+	public ResponseEntity<?> createMusicRoom(@RequestBody MusicRequestDTO.Create createDTO){
+		return musicRoomService.createMusicRoom(createDTO);
+	}
+
+	@GetMapping("/musicRoom")
+	public ResponseEntity<?> getRoomInfoHave(@RequestParam("memberSeq") Long memberSeq){
+		return musicRoomService.getOwnerRoomList(memberSeq);
+	}
+
+	@PatchMapping("/musicRoom")
+	public ResponseEntity<?> changeRoomInfo(@RequestBody MusicRequestDTO.ChangeInfo changeInfoDTO){
+		return musicRoomService.changeRoomInfo(changeInfoDTO);
+	}
+
+	@DeleteMapping("/musicRoom")
+	public ResponseEntity<?> deletedMusicRoom(@RequestBody MusicRequestDTO.Delete deleteDTO){
+		return musicRoomService.deleteMusicRoom(deleteDTO);
+	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/application/impl/MusicMemberServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/application/impl/MusicMemberServiceImpl.java
@@ -10,6 +10,8 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
@@ -27,5 +29,11 @@ public class MusicMemberServiceImpl implements MusicMemberService {
 						.ownerSeq(member.getMemberSeq())
 						.build()
 		);
+	}
+
+	@Override
+	public void deletedRoomDetails(MusicRoom musicRoom) {
+		Optional<MusicRoomMember> findMRM = musicMemberRepository.findByMusicRoom(musicRoom);
+		musicMemberRepository.delete(findMRM.get());
 	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/application/impl/check/MusicMemberCheckServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/application/impl/check/MusicMemberCheckServiceImpl.java
@@ -1,8 +1,10 @@
 package dy.whatsong.domain.music.application.impl.check;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import dy.whatsong.domain.member.entity.Member;
 import dy.whatsong.domain.music.application.service.check.MusicMemberCheckService;
 import dy.whatsong.domain.music.entity.MusicRoomMember;
+import dy.whatsong.domain.music.entity.QMusicRoomMember;
 import dy.whatsong.domain.music.repo.MusicMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -20,9 +22,14 @@ public class MusicMemberCheckServiceImpl implements MusicMemberCheckService {
 
 	private final MusicMemberRepository musicMemberRepository;
 
+	private final JPAQueryFactory jpaQueryFactory;
+
 	@Override
 	public List<MusicRoomMember> getInfoMRMListByMember(Member member) {
-		Optional<List<MusicRoomMember>> byMember = musicMemberRepository.findByMember(member);
-		return byMember.get();
+		QMusicRoomMember qmrm=QMusicRoomMember.musicRoomMember;
+		List<MusicRoomMember> fetchResult = jpaQueryFactory.selectFrom(qmrm)
+				.where(qmrm.member.eq(member))
+				.fetch();
+		return fetchResult;
 	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/application/service/MusicMemberService.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/application/service/MusicMemberService.java
@@ -5,4 +5,5 @@ import dy.whatsong.domain.music.entity.MusicRoom;
 
 public interface MusicMemberService {
 	void createdRoomDetails(MusicRoom musicRoom, Member member);
+	void deletedRoomDetails(MusicRoom musicRoom);
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/application/service/MusicRoomService.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/application/service/MusicRoomService.java
@@ -7,7 +7,7 @@ import org.springframework.http.ResponseEntity;
 public interface MusicRoomService {
 	ResponseEntity<?> createMusicRoom(MusicRequestDTO.Create createDTO);
 
-	ResponseEntity<?> getOwnerRoomList(MusicRequestDTO.OwnerInfo ownerInfoDTO);
+	ResponseEntity<?> getOwnerRoomList(Long memberSeq);
 
 	ResponseEntity<?> changeRoomInfo(MusicRequestDTO.ChangeInfo changeInfoDTO);
 

--- a/whatsong/src/main/java/dy/whatsong/domain/music/dto/request/MusicRequestDTO.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/dto/request/MusicRequestDTO.java
@@ -15,10 +15,10 @@ public class MusicRequestDTO {
 		private AccessAuth accessAuth;
 	}
 
-	@Getter
+	/*@Getter
 	public static class OwnerInfo{
-		private String oauthId;
-	}
+		private Long memberSeq;
+	}*/
 
 	@Getter
 	public static class ChangeInfo{

--- a/whatsong/src/main/java/dy/whatsong/domain/music/dto/response/RoomResponseDTO.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/dto/response/RoomResponseDTO.java
@@ -24,4 +24,20 @@ public class RoomResponseDTO {
 		@Enumerated(EnumType.STRING)
 		private AccessAuth accessAuth;
 	}
+
+	@Getter
+	@Builder
+	public static class Change{
+		private Long musicRoomSeq;
+
+		private String roomName;
+
+		private String roomCode;
+
+		private String category;
+
+		@Enumerated(EnumType.STRING)
+		private AccessAuth accessAuth;
+	}
+
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/dto/response/RoomResponseDTO.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/dto/response/RoomResponseDTO.java
@@ -1,0 +1,27 @@
+package dy.whatsong.domain.music.dto.response;
+
+import dy.whatsong.domain.music.entity.AccessAuth;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Getter
+public class RoomResponseDTO {
+
+	@Getter
+	@Builder
+	public static class Have{
+		private Long musicRoomSeq;
+
+		private String roomName;
+
+		private String roomCode;
+
+		private String category;
+
+		@Enumerated(EnumType.STRING)
+		private AccessAuth accessAuth;
+	}
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/music/entity/MusicRoom.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/entity/MusicRoom.java
@@ -46,4 +46,14 @@ public class MusicRoom {
 				.category(category)
 				.build();
 	}
+
+	public RoomResponseDTO.Change toChangeInfoDTO(){
+		return RoomResponseDTO.Change.builder()
+				.musicRoomSeq(musicRoomSeq)
+				.roomCode(roomCode)
+				.accessAuth(accessAuth)
+				.category(category)
+				.roomName(roomName)
+				.build();
+	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/entity/MusicRoom.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/entity/MusicRoom.java
@@ -1,6 +1,7 @@
 package dy.whatsong.domain.music.entity;
 
 import dy.whatsong.domain.music.dto.request.MusicRequestDTO;
+import dy.whatsong.domain.music.dto.response.RoomResponseDTO;
 import lombok.*;
 
 import javax.persistence.*;
@@ -34,5 +35,15 @@ public class MusicRoom {
 		this.category=changeInfoDTO.getCategory();
 		this.roomName=changeInfoDTO.getName();
 		return this;
+	}
+
+	public RoomResponseDTO.Have toHaveRoomDTO(){
+		return RoomResponseDTO.Have.builder()
+				.musicRoomSeq(musicRoomSeq)
+				.roomCode(roomCode)
+				.roomName(roomName)
+				.accessAuth(accessAuth)
+				.category(category)
+				.build();
 	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/entity/MusicRoomMember.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/entity/MusicRoomMember.java
@@ -21,7 +21,7 @@ public class MusicRoomMember {
 	private Member member;
 
 	@ManyToOne
-	@JoinColumn(name = "musicRoomSeq")
+	@JoinColumn(name = "music_room_seq")
 	private MusicRoom musicRoom;
 
 	private Long ownerSeq;

--- a/whatsong/src/main/java/dy/whatsong/domain/music/repo/MusicMemberRepository.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/repo/MusicMemberRepository.java
@@ -1,6 +1,7 @@
 package dy.whatsong.domain.music.repo;
 
 import dy.whatsong.domain.member.entity.Member;
+import dy.whatsong.domain.music.entity.MusicRoom;
 import dy.whatsong.domain.music.entity.MusicRoomMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,4 +10,5 @@ import java.util.Optional;
 
 public interface MusicMemberRepository extends JpaRepository<MusicRoomMember,Long> {
 	Optional<List<MusicRoomMember>> findByMember(Member member);
+	Optional<MusicRoomMember> findByMusicRoom(MusicRoom musicRoom);
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/application/impl/ReservationServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/application/impl/ReservationServiceImpl.java
@@ -1,0 +1,52 @@
+package dy.whatsong.domain.reservation.application.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import dy.whatsong.domain.reservation.application.service.ReservationService;
+import dy.whatsong.domain.reservation.dto.ReservationDTO;
+import dy.whatsong.domain.reservation.entity.Recognize;
+import dy.whatsong.domain.reservation.entity.Reservation;
+import dy.whatsong.domain.reservation.repo.ReservationRepository;
+import dy.whatsong.domain.youtube.dto.VideoDTO;
+import dy.whatsong.global.annotation.EssentialServiceLayer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@EssentialServiceLayer
+@RequiredArgsConstructor
+@Log4j2
+public class ReservationServiceImpl implements ReservationService {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	private final ReservationRepository reservationRepository;
+
+	@Override
+	public ResponseEntity<?> reservationMusic(ReservationDTO.Select selectDTO) {
+		Reservation currentReservation = reservationRepository.save(Reservation.builder()
+				.reservationId(UUID.randomUUID().toString())
+				.roomSeq(selectDTO.getRoomSeq())
+				.selectVideo(ReservationDTO.SelectVideo
+						.builder()
+						.videoId(selectDTO.getVideoId())
+						.channelName(selectDTO.getChannelName())
+						.thumbnailUrl(selectDTO.getThumbnailUrl())
+						.title(selectDTO.getTitle())
+						.build())
+				.recognize(Recognize.NONE)
+				.build());
+
+		return new ResponseEntity<>(currentReservation, HttpStatus.OK);
+	}
+
+	@Override
+	public ResponseEntity<?> reservationList(Long roomSeq) {
+		Optional<List<Reservation>> findRList = reservationRepository.findByRoomSeq(roomSeq);
+		return new ResponseEntity<>(findRList.get(),HttpStatus.OK);
+	}
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/application/impl/ReservationServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/application/impl/ReservationServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -46,7 +47,11 @@ public class ReservationServiceImpl implements ReservationService {
 
 	@Override
 	public ResponseEntity<?> reservationList(Long roomSeq) {
-		Optional<List<Reservation>> findRList = reservationRepository.findByRoomSeq(roomSeq);
-		return new ResponseEntity<>(findRList.get(),HttpStatus.OK);
+		List<Reservation> reservationList=new ArrayList<>();
+		reservationRepository.findAll()
+				.forEach(reservation -> {
+					if(reservation.getRoomSeq().equals(roomSeq)) reservationList.add(reservation);
+				});
+		return new ResponseEntity<>(reservationList,HttpStatus.OK);
 	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/application/service/ReservationService.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/application/service/ReservationService.java
@@ -1,0 +1,12 @@
+package dy.whatsong.domain.reservation.application.service;
+
+import dy.whatsong.domain.reservation.dto.ReservationDTO;
+import dy.whatsong.domain.youtube.dto.VideoDTO;
+import org.springframework.http.ResponseEntity;
+
+public interface ReservationService {
+	ResponseEntity<?> reservationMusic(ReservationDTO.Select selectDTO);
+
+	ResponseEntity<?> reservationList(Long roomSeq);
+
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/dto/ReservationDTO.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/dto/ReservationDTO.java
@@ -1,0 +1,29 @@
+package dy.whatsong.domain.reservation.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+public class ReservationDTO {
+	@Getter
+	public static class Select{
+		private String videoId;
+		private String title;
+		private String channelName;
+		private String thumbnailUrl;
+		private Long roomSeq;
+	}
+
+	@Getter
+	@Builder
+	public static class SelectVideo{
+		private String videoId;
+		private String title;
+		private String channelName;
+		private String thumbnailUrl;
+	}
+
+	@Getter
+	public static class List{
+		private Long roomSeq;
+	}
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/entity/Recognize.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/entity/Recognize.java
@@ -1,0 +1,5 @@
+package dy.whatsong.domain.reservation.entity;
+
+public enum Recognize {
+	APPROVE,NONE
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/entity/Reservation.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/entity/Reservation.java
@@ -1,19 +1,20 @@
 package dy.whatsong.domain.reservation.entity;
 
 import dy.whatsong.domain.reservation.dto.ReservationDTO;
-import dy.whatsong.domain.youtube.dto.VideoDTO;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.redis.core.RedisHash;
 
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
-import javax.persistence.Id;
+import org.springframework.data.annotation.Id;
 
-@RedisHash(value = "resevation",timeToLive = 86400)
+
+@RedisHash(value = "reservation",timeToLive = 86400)
 @Getter
 @Builder
 public class Reservation {
+
 	@Id
 	private String reservationId;
 
@@ -24,3 +25,4 @@ public class Reservation {
 	@Enumerated(EnumType.STRING)
 	private Recognize recognize;
 }
+

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/entity/Reservation.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/entity/Reservation.java
@@ -1,0 +1,26 @@
+package dy.whatsong.domain.reservation.entity;
+
+import dy.whatsong.domain.reservation.dto.ReservationDTO;
+import dy.whatsong.domain.youtube.dto.VideoDTO;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+
+@RedisHash(value = "resevation",timeToLive = 86400)
+@Getter
+@Builder
+public class Reservation {
+	@Id
+	private String reservationId;
+
+	private Long roomSeq;
+
+	private ReservationDTO.SelectVideo selectVideo;
+
+	@Enumerated(EnumType.STRING)
+	private Recognize recognize;
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/repo/ReservationRepository.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/repo/ReservationRepository.java
@@ -1,0 +1,11 @@
+package dy.whatsong.domain.reservation.repo;
+
+import dy.whatsong.domain.reservation.entity.Reservation;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReservationRepository extends CrudRepository<Reservation,String> {
+	Optional<List<Reservation>> findByRoomSeq(Long roomseq);
+}

--- a/whatsong/src/main/java/dy/whatsong/domain/reservation/repo/ReservationRepository.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/reservation/repo/ReservationRepository.java
@@ -3,9 +3,5 @@ package dy.whatsong.domain.reservation.repo;
 import dy.whatsong.domain.reservation.entity.Reservation;
 import org.springframework.data.repository.CrudRepository;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface ReservationRepository extends CrudRepository<Reservation,String> {
-	Optional<List<Reservation>> findByRoomSeq(Long roomseq);
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/youtube/api/YoutubeAPIController.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/youtube/api/YoutubeAPIController.java
@@ -18,6 +18,6 @@ public class YoutubeAPIController {
 
 	@PostMapping("/youtube/search")
 	public ResponseEntity<?> searchByKeywordOnYoutube(@RequestBody VideoDTO.Keyword keywordDTO) throws JsonProcessingException {
-		return youtubeService.searchOnYoutube(keywordDTO.getKeyword());
+		return youtubeService.searchOnYoutube(keywordDTO);
 	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/youtube/application/impl/YoutubeServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/youtube/application/impl/YoutubeServiceImpl.java
@@ -35,14 +35,13 @@ public class YoutubeServiceImpl implements YoutubeService {
 	private static final String API_URL_SNIPPET = "https://www.googleapis.com/youtube/v3/search";
 
 	@Override
-	public ResponseEntity<?> searchOnYoutube(String searchQuery) {
+	public ResponseEntity<?> searchOnYoutube(VideoDTO.Keyword keyword) {
 		log.info("KEY="+API_KEY);
 		log.info("KEY="+MAX_QUERY);
-		log.info("searchQuery="+searchQuery);
 		String target_url= API_URL_SNIPPET +
 				"?part="+YOUTUBE_PART +
 				"&maxResults="+MAX_QUERY +
-				"&q=" + searchQuery +
+				"&q=" + keyword.getKeyword() +
 				"&key=" + API_KEY +
 				"&type="+YOUTUBE_TYPE;
 

--- a/whatsong/src/main/java/dy/whatsong/domain/youtube/application/service/YoutubeService.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/youtube/application/service/YoutubeService.java
@@ -1,8 +1,9 @@
 package dy.whatsong.domain.youtube.application.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import dy.whatsong.domain.youtube.dto.VideoDTO;
 import org.springframework.http.ResponseEntity;
 
 public interface YoutubeService {
-	ResponseEntity<?> searchOnYoutube(String searchQuery) throws JsonProcessingException;
+	ResponseEntity<?> searchOnYoutube(VideoDTO.Keyword keywordDTO) throws JsonProcessingException;
 }

--- a/whatsong/src/main/java/dy/whatsong/global/config/redis/RedisConfig.java
+++ b/whatsong/src/main/java/dy/whatsong/global/config/redis/RedisConfig.java
@@ -1,0 +1,29 @@
+package dy.whatsong.global.config.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory(){
+		return new LettuceConnectionFactory(redisProperties.getHost(),redisProperties.getPort());
+	}
+
+	@Bean
+	public RedisTemplate<?, ?> redisTemplate() {
+		RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/whatsong/src/main/java/dy/whatsong/global/config/redis/RedisProperties.java
+++ b/whatsong/src/main/java/dy/whatsong/global/config/redis/RedisProperties.java
@@ -1,0 +1,15 @@
+package dy.whatsong.global.config.redis;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration
+public class RedisProperties {
+	@Value("${spring.redis.host}")
+	private String host;
+
+	@Value("${spring.redis.port}")
+	private int port;
+}

--- a/whatsong/src/main/resources/application.yml
+++ b/whatsong/src/main/resources/application.yml
@@ -2,6 +2,10 @@
 # PostgreSQL Settings
 ######################################################################
 spring:
+  redis:
+    host: localhost
+    port: 6379
+
   mvc:
     pathmatch:
       matching-strategy: ant_path_matcher


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- [ X ] 기능 추가
- [ X ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 초기 설정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
- feat/friends-> main

## 반영 사항
-  queryDsl을 이용한 `BooleanExpress`를 사용하여 비즈니스 로직 작성
  - `search`에서는 자신을 제외한 검색 조건과 부합한 회원 데이터 반환
     - 추후 이미 친구인 사람의 경우에 대한 처리 논의
  - `apply`에서는 자신과 현재 요청 대상이 이미 친구인지 판단하는 로직 사용

## 유의사항
- `Profile` 도메인 변경에 따라 달라짐

## 참여자
- 코드작성자 : @seonghoo1217 
- 리뷰어 및 확인자 : @itsChrisJang 