### PR TITLE
#16 feat : 친구추가를 팔로우 도메인으로 변경 및 기능개발

### DIFF
--- a/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
@@ -1,6 +1,7 @@
 package dy.whatsong.domain.member.application.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import dy.whatsong.domain.member.application.service.MemberDetailService;
 import dy.whatsong.domain.member.dto.MemberRequestDTO;
@@ -80,17 +81,15 @@ public class MemberDetailServiceImpl implements MemberDetailService {
 
 	@Override
 	public ResponseEntity<?> memberUnfollowRequest(MemberRequestDTO.FriendsApply friendsApplyDTO) {
-		return null;
-	}
+		QFriendsState qf=QFriendsState.friendsState;
+		Long o = friendsApplyDTO.getOwnerSeq();
+		Long t = friendsApplyDTO.getTargetSeq();
+		BooleanExpression findCondition = qf.ownerSeq.eq(o).
+				and(qf.targetSeq.eq(t));
 
-	public Member testDummy(){
-		return Member.builder()
-				.memberSeq(1L)
-				.nickname("dummy")
-				.innerNickname("bomin")
-				.memberRole(MemberRole.USER)
-				.email("dummy@dummy.com")
-				.imgURL("https://avatars.githubusercontent.com/u/65716445?v=4")
-				.build();
+		jpaQueryFactory.delete(qf)
+				.where(findCondition);
+
+		return new ResponseEntity<>(o+"unfollowed"+t,HttpStatus.OK);
 	}
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/application/impl/MemberDetailServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @EssentialServiceLayer
 @RequiredArgsConstructor
@@ -65,6 +66,16 @@ public class MemberDetailServiceImpl implements MemberDetailService {
 				.from(qfs)
 				.where(friendConditon)
 				.fetchFirst() != null;
+	}
+
+	public boolean isOwnerAlreadyFriends(Long ownerSeq,Long targetSeq){
+		Optional<List<FriendsState>> findFS = friendsStateRepository.findByOwnerSeq(ownerSeq);
+		for (FriendsState fs:findFS.get()){
+			if (fs.getTargetSeq().equals(targetSeq)){
+				return true;
+			}
+		}
+		return false;
 	}
 
 	@Override

--- a/whatsong/src/main/java/dy/whatsong/domain/member/application/service/MemberDetailService.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/application/service/MemberDetailService.java
@@ -6,7 +6,9 @@ import org.springframework.http.ResponseEntity;
 public interface MemberDetailService {
 	ResponseEntity<?> memberFriendRequest(MemberRequestDTO.FriendsApply friendsApplyDTO);
 
-	boolean isAlreadyFriends(Long ownerSeq,Long requestMemberSeq);
+	boolean isOwnerAlreadyFriendsRequest(Long ownerSeq, Long requestMemberSeq);
 
 	ResponseEntity<?> memberSearchOnFriendsList(MemberRequestDTO.Search searchDTO);
+
+	ResponseEntity<?> memberUnfollowRequest(MemberRequestDTO.FriendsApply friendsApplyDTO);
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/member/repo/FriendsStateRepository.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/repo/FriendsStateRepository.java
@@ -3,8 +3,9 @@ package dy.whatsong.domain.member.repo;
 import dy.whatsong.domain.member.entity.FriendsState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FriendsStateRepository extends JpaRepository<FriendsState,Long> {
-	Optional<FriendsState> findByOwnerSeq(Long ownerSeq);
+	Optional<List<FriendsState>> findByOwnerSeq(Long ownerSeq);
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/member/repo/FriendsStateRepository.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/member/repo/FriendsStateRepository.java
@@ -3,5 +3,8 @@ package dy.whatsong.domain.member.repo;
 import dy.whatsong.domain.member.entity.FriendsState;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FriendsStateRepository extends JpaRepository<FriendsState,Long> {
+	Optional<FriendsState> findByOwnerSeq(Long ownerSeq);
 }

--- a/whatsong/src/main/java/dy/whatsong/domain/music/application/impl/MusicRoomServiceImpl.java
+++ b/whatsong/src/main/java/dy/whatsong/domain/music/application/impl/MusicRoomServiceImpl.java
@@ -2,7 +2,6 @@ package dy.whatsong.domain.music.application.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import dy.whatsong.domain.member.application.impl.MemberDetailServiceImpl;
 import dy.whatsong.domain.member.application.service.MemberDetailService;
 import dy.whatsong.domain.member.entity.Member;
 import dy.whatsong.domain.member.entity.MemberRole;
@@ -21,7 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -183,7 +181,7 @@ public class MusicRoomServiceImpl implements MusicRoomService {
 		Long ownerSeq = jpaQueryFactory.selectFrom(qmrm)
 				.where(qmrm.musicRoom.eq(eqMR))
 				.fetchOne().getOwnerSeq();
-		if(memberDetailService.isAlreadyFriends(ownerSeq,dummyMember.getMemberSeq())){
+		if(memberDetailService.isOwnerAlreadyFriendsRequest(ownerSeq,dummyMember.getMemberSeq())){
 			return new ResponseEntity<>(ACCESS_ALLOW,HttpStatus.OK);
 		}
 


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- [X] 기능 추가
- [X] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 초기 설정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 배포환경
- [ ] 문서 수정 (ex. README)

## 반영 브랜치
- feat/friends-> main

## 반영 사항
- 친구추가 도메인을 서로 `follow`하는 형식으로 도메인 변경
- 그에 따라 팔로우 취소 및 맞팔로우상태 확인 가능 


## 유의사항
- Follow 상태 조회 로직 변경가능성

## 관련이슈
- #16 

## 참여자
- 코드작성자 : @seonghoo1217 
- 리뷰어 및 확인자 : @itsChrisJang 